### PR TITLE
adds example for single quote string

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ more characters in between:
 typeof "I am a string.";
 //=> "string"
 
-typeof "Me too!";
+typeof 'Me too!';
 //=> "string"
 
 typeof `Me three!`;


### PR DESCRIPTION
Closes #1 

Thanks for flagging this @garrettstrohm! I went ahead and changed the second example in the strings section to use single quotes. We appreciate you taking the time to raise this issue! Please note this will probably not be reflected in your Canvas page, but will be reflected in Github as well as Canvas for future students.
Thanks again!
Gracie